### PR TITLE
Update GTFS feed link and wget command for 2026

### DIFF
--- a/doc/get-started.mdx
+++ b/doc/get-started.mdx
@@ -12,10 +12,10 @@ npm i -g minotor
 
 ### Data sources
 
-[opentransportdata.swiss](https://opentransportdata.swiss) provides a [GTFS feed for Switzerland](https://data.opentransportdata.swiss/en/dataset/timetable-2025-gtfs2020) that is supported by the library.
+[opentransportdata.swiss](https://opentransportdata.swiss) provides a [GTFS feed for Switzerland](https://data.opentransportdata.swiss/en/dataset/timetable-2026-gtfs2020) that is supported by the library.
 
 ```bash
-wget https://data.opentransportdata.swiss/en/dataset/timetable-2025-gtfs2020/permalink -O gtfs-feed.zip
+wget https://data.opentransportdata.swiss/en/dataset/timetable-2026-gtfs2020/permalink -O gtfs-feed.zip
 ```
 
 GTFS feeds from other providers and other regions can be used as well but are not officially supported yet.


### PR DESCRIPTION
This pull request updates the documentation to reference the latest GTFS feed for Switzerland. The example now points to the 2026 dataset instead of the 2025 dataset.